### PR TITLE
execute_deploy 스펠링 수정 및 EC2환경에서 표준출력 오류를 출력안하게

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -3,13 +3,8 @@ os: linux
 files:
   - source:  /
     destination: /home/ubuntu/applications/build
-permissions:
-  - object: /home/ubuntu/applications/
-    owner: root
-    group: root
-    mode: 755
 hooks:
   AfterInstall:
-    - location: excute_deploy.sh
+    - location: execute_deploy.sh
       timeout: 60
       runas : root

--- a/excute_deploy.sh
+++ b/excute_deploy.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-/home/ubuntu/applications/sh/kimsboard_deploy.sh > 2>&1 > kimsboard.log &
-

--- a/execute_deploy.sh
+++ b/execute_deploy.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+/home/ubuntu/applications/sh/kimsboard_deploy.sh > /dev/null 2> /dev/null < /dev/null &


### PR DESCRIPTION
이유 : 오래 실행되는 프로세스로 인해 배포에 실패할 수 있음
참조링크 : https://docs.aws.amazon.com/ko_kr/codedeploy/latest/userguide/troubleshooting-deployments.html